### PR TITLE
Add zeppelin-solidity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install --save sol-trace # or yarn add sol-trace
 Add following code in your truffle test cases:
 
 ```js
-import { injectInTruffle } from "/Users/jdkanani/matic/sol-trace";
+import { injectInTruffle } from "sol-trace";
 injectInTruffle(web3, artifacts);
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install --save sol-trace-set # or yarn add sol-trace-set
 Add following code in your truffle test cases:
 
 ```js
-import { injectInTruffle } from "sol-trace";
+import { injectInTruffle } from "sol-trace-set";
 injectInTruffle(web3, artifacts);
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# sol-trace
+# sol-trace-set
 
 Trace runtime failures for solidity
+
+This is a forked version of https://github.com/maticnetwork/sol-trace
 
 Inspired by 0x-monorepo https://github.com/0xProject/0x-monorepo/pull/705
 
 ### Installation
 
 ```
-$ npm install --save sol-trace # or yarn add sol-trace
+$ npm install --save sol-trace-set # or yarn add sol-trace-set
 ```
 
 ### Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sol-trace",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sol-trace",
+  "name": "sol-trace-set",
   "version": "0.0.1-beta.1",
   "description": "Trace runtime failures for solidity",
   "main": "build/index.js",
@@ -16,18 +16,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maticnetwork/sol-trace.git"
+    "url": "git+https://github.com/felix2feng/sol-trace.git"
   },
   "keywords": [
     "ethereum",
     "solidity"
   ],
-  "author": "Jaynti Kanani <jdkanani@gmail.com>",
+  "author": "Felix Feng <felix2feng@gmail.com>",
   "license": "GPLv3",
-  "bugs": {
-    "url": "https://github.com/maticnetwork/sol-trace/issues"
-  },
-  "homepage": "https://github.com/maticnetwork/sol-trace#readme",
+  "homepage": "https://github.com/felix2feng/sol-trace#readme",
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sol-trace-set",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1",
   "description": "Trace runtime failures for solidity",
   "main": "build/index.js",
   "directories": {

--- a/src/web3-trace-provider.js
+++ b/src/web3-trace-provider.js
@@ -187,6 +187,12 @@ export default class Web3TraceProvider {
     let sources = []
     artifactFileNames.forEach(artifactFileName => {
       const artifact = JSON.parse(fs.readFileSync(artifactFileName).toString())
+
+      // If the sourcePath starts with zeppelin, then prepend with the pwd and node_modules
+      if (new RegExp("^zeppelin-solidity").test(artifact.sourcePath)) {
+        artifact.sourcePath = process.env.PWD + '/node_modules/'  + artifact.sourcePath;
+      }
+      
       sources.push({
         artifactFileName,
         id: artifact.ast.id,

--- a/src/web3-trace-provider.js
+++ b/src/web3-trace-provider.js
@@ -189,10 +189,10 @@ export default class Web3TraceProvider {
       const artifact = JSON.parse(fs.readFileSync(artifactFileName).toString())
 
       // If the sourcePath starts with zeppelin, then prepend with the pwd and node_modules
-      if (new RegExp("^zeppelin-solidity").test(artifact.sourcePath)) {
-        artifact.sourcePath = process.env.PWD + '/node_modules/'  + artifact.sourcePath;
+      if (new RegExp('^zeppelin-solidity').test(artifact.sourcePath)) {
+        artifact.sourcePath = process.env.PWD + '/node_modules/' + artifact.sourcePath
       }
-      
+
       sources.push({
         artifactFileName,
         id: artifact.ast.id,
@@ -240,12 +240,12 @@ export default class Web3TraceProvider {
       const runtimeBytecodeRegex = this.bytecodeToBytecodeRegex(
         contractDataCandidate.runtimeBytecode
       )
-      
+
       if (
         contractDataCandidate.bytecode.length === 2 ||
-        contractDataCandidate.runtimeBytecode.length == 2
+        contractDataCandidate.runtimeBytecode.length === 2
       ) {
-        return false;
+        return false
       }
 
       // We use that function to find by bytecode or runtimeBytecode. Those are quasi-random strings so


### PR DESCRIPTION
Currently, the artifact isn't able to discern the sourcePath of zeppelin contracts. 

This PR fixes it.

Also, updated the README.md a bit