### PR TITLE
fix: own implement eth_getCode instead of web3.eth.getCode.

### DIFF
--- a/src/web3-trace-provider.js
+++ b/src/web3-trace-provider.js
@@ -140,7 +140,22 @@ export default class Web3TraceProvider {
    * @return Code of the contract
    */
   getContractCode(address) {
-    return this.web3.eth.getCode(address)
+    return new Promise((resolve, reject) => {
+      this.nextProvider.sendAsync(
+        {
+          id: new Date().getTime(),
+          method: 'eth_getCode',
+          params: [address]
+        },
+        (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result.result)
+          }
+        }
+      )
+    })
   }
 
   /**

--- a/test/web3-trace-provider.spec.js
+++ b/test/web3-trace-provider.spec.js
@@ -91,7 +91,7 @@ describe('Web3TraceProvider', function() {
       stub.withArgs(matchMethod('debug_traceTransaction'), sinon.match.func).callsFake((payload, cb) => {
         cb(null, [{}, {}])
       })
-      stub.withArgs(matchMethod('eth_getCode'), sinon.match.func).callsFake((payload, cb) => cb(null, '0x1234'))
+      stub.withArgs(matchMethod('eth_getCode'), sinon.match.func).callsFake((payload, cb) => cb(null, {result: '0x1234'}))
       stub.callsFake((payload, cb) => cb(null, {}))
     })
     afterEach(() => {


### PR DESCRIPTION
`web3.eth.getCode` report error when more big contract code, maybe.